### PR TITLE
patch-enable-diskbursting

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -272,7 +272,8 @@
       "caching": "ReadOnly",
       "writeAcceleratorEnabled": false,
       "storageAccountType": "Premium_LRS",
-      "diskSizeGB": 1023
+      "diskSizeGB": 1023,
+      "burstingEnabled": "true"
     },
     "tempDbPath":  "D:\\TEMPDB",
     "scriptFolder": ".",


### PR DESCRIPTION
Add "burstingEnabled": "true" //Feature flag to enable disk bursting on disks > 512 GiB
https://docs.microsoft.com/en-us/azure/virtual-machines/disks-enable-bursting?tabs=azure-resource-manager